### PR TITLE
deploy.rb : configuration de bundler pour installer les gems localement

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -52,6 +52,17 @@ set :shared_files, fetch(:shared_files, []).push(
   'config/sunspot.yml'
 )
 
+namespace :bundle do
+  desc 'Sets the Bundler config options.'
+  task :config do
+    comment %{Setting the Bundler config options (and cleaning default options)}
+    set :bundle_options, -> { '' }
+    command %{#{fetch(:bundle_bin)} config set --local deployment 'true'}
+    command %{#{fetch(:bundle_bin)} config set --local path '#{fetch(:bundle_path)}'}
+    command %{#{fetch(:bundle_bin)} config set --local without '#{fetch(:bundle_withouts)}'}
+  end
+end
+
 task :samhain_db_update do
   command %{sudo /usr/local/sbin/update-samhain-db.sh "#{fetch(:deploy_to)}"}
 end
@@ -78,8 +89,9 @@ task :deploy do
     # instance of your project.
     invoke :'git:clone'
     invoke :'deploy:link_shared_paths'
-    set :bundle_options, fetch(:bundle_options) + ' --clean'
+    invoke :'bundle:config'
     invoke :'bundle:install'
+    invoke :'bundle:clean'
     invoke :'rails:db_migrate'
     invoke :'deploy:cleanup'
 


### PR DESCRIPTION
Il n'est plus permis d'installer les gems sur le système complet depuis le passage à des comptes SSH personnels et à un compte système séparé par machine.